### PR TITLE
Exclude Linux build target

### DIFF
--- a/.github/workflows/PlaytestBuild.yml
+++ b/.github/workflows/PlaytestBuild.yml
@@ -15,7 +15,7 @@ jobs:
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+          #- StandaloneLinux64 # Build a Linux 64-bit standalone.
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Reasons: 
- Linux build works terrible
- Spends electricity (could be spent more practically)
- Proton works